### PR TITLE
EB-18050: Add checks for doctrine classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         php_version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
     steps:

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "type": "phpcodesniffer-standard",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "slevomat/coding-standard": "^6.4",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.4",
+        "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^0.12.56",
         "phpstan/phpstan-phpunit": "^0.12.16",
         "phpmd/phpmd": "^2.9"

--- a/lib/phpcs/phpcs.xml
+++ b/lib/phpcs/phpcs.xml
@@ -6,6 +6,8 @@
     <!-- Show progress of the run -->
     <arg value="sp"/>
 
+    <config name="installed_paths" value="../../slevomat/coding-standard,../../etsglobal/php-static-analysis/src"/>
+
     <rule ref="./rules/base.xml"/>
     <rule ref="./rules/etsglobal.xml"/>
     <rule ref="./rules/psr.xml"/>

--- a/lib/phpcs/rules/etsglobal.xml
+++ b/lib/phpcs/rules/etsglobal.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="ETSGlobal" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <rule ref="ETSGlobalCodingStandard.Doctrine.ForbidDoctrineClasses"/>
     <rule ref="ETSGlobalCodingStandard.Logger.SnakeCaseContextKeys"/>
     <rule ref="ETSGlobalCodingStandard.RabbitMQ.ValidMessageStructure"/>
     <rule ref="ETSGlobalCodingStandard.RabbitMQ.ValidPublisherMethodName"/>

--- a/lib/phpcs/rules/etsglobal.xml
+++ b/lib/phpcs/rules/etsglobal.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="ETSGlobal" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <rule ref="ETSGlobalCodingStandard.Doctrine.ForbidRepositoryInjection"/>
     <rule ref="ETSGlobalCodingStandard.Doctrine.ForbidDoctrineClasses"/>
     <rule ref="ETSGlobalCodingStandard.Logger.SnakeCaseContextKeys"/>
     <rule ref="ETSGlobalCodingStandard.RabbitMQ.ValidMessageStructure"/>

--- a/lib/phpcs/rules/etsglobal.xml
+++ b/lib/phpcs/rules/etsglobal.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="ETSGlobal" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
-    <config name="installed_paths" value="../../etsglobal/php-static-analysis/src,../../../src"/>
-
     <rule ref="ETSGlobalCodingStandard.Logger.SnakeCaseContextKeys"/>
     <rule ref="ETSGlobalCodingStandard.RabbitMQ.ValidMessageStructure"/>
     <rule ref="ETSGlobalCodingStandard.RabbitMQ.ValidPublisherMethodName"/>

--- a/lib/phpcs/rules/slevomat.xml
+++ b/lib/phpcs/rules/slevomat.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="ETSGlobal" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
-    <config name="installed_paths" value="../../slevomat/coding-standard"/>
-
     <!-- Require comma after last element in multi-line array -->
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <!-- Disallows implicit array creation. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,13 +7,10 @@
 
     <exclude-pattern>tests/ETSGlobalCodingStandard/*/data/*</exclude-pattern>
 
+    <config name="installed_paths" value="../../slevomat/coding-standard,../../../src"/>
+
     <rule ref="./lib/phpcs/rules/base.xml"/>
     <rule ref="./lib/phpcs/rules/etsglobal.xml"/>
     <rule ref="./lib/phpcs/rules/psr.xml"/>
     <rule ref="./lib/phpcs/rules/slevomat.xml"/>
-
-    <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall">
-        <!-- Exclude to pass tests on PHP 7.2 -->
-        <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/>
-    </rule>
 </ruleset>

--- a/src/ETSGlobalCodingStandard/Helpers/PropertyHelper.php
+++ b/src/ETSGlobalCodingStandard/Helpers/PropertyHelper.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Helpers;
+
+use PHP_CodeSniffer\Files\File;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use SlevomatCodingStandard\Helpers\Annotation\PropertyAnnotation;
+use SlevomatCodingStandard\Helpers\AnnotationHelper;
+use SlevomatCodingStandard\Helpers\AnnotationTypeHelper;
+
+class PropertyHelper
+{
+    public static function getPropertyType(File $phpcsFile, int $propertyPointer): ?string
+    {
+        // Check native typehint
+        $propertyTypehint = \SlevomatCodingStandard\Helpers\PropertyHelper::findTypeHint($phpcsFile, $propertyPointer);
+        if ($propertyTypehint !== null) {
+            return $propertyTypehint->getTypeHint();
+        }
+
+        // Check PHPDoc type (legacy support)
+        $varAnnotations = AnnotationHelper::getAnnotationsByName($phpcsFile, $propertyPointer, '@var');
+        /** @var PropertyAnnotation|null $propertyAnnotation */
+        $propertyAnnotation = count($varAnnotations) > 0 ? $varAnnotations[0] : null;
+
+        if ($propertyAnnotation === null) {
+            return null;
+        }
+
+        $type = $propertyAnnotation->getType();
+        if ($type instanceof IntersectionTypeNode || $type instanceof UnionTypeNode || $type instanceof NullableTypeNode) {
+            return null;
+        }
+
+        if (AnnotationTypeHelper::containsOneType($type)) {
+            return AnnotationTypeHelper::getTypeHintFromOneType($type);
+        }
+
+        return null;
+    }
+}

--- a/src/ETSGlobalCodingStandard/Helpers/WildcardHelper.php
+++ b/src/ETSGlobalCodingStandard/Helpers/WildcardHelper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Helpers;
+
+class WildcardHelper
+{
+    /**
+     * Searches for a "glob" pattern in a string.
+     *
+     * @param string $pattern The "glob" pattern
+     * @param string $subject The string to search from
+     *
+     * @return bool True if the pattern was found in the subject string, false otherwise.
+     */
+    public static function match(string $pattern, string $subject): bool
+    {
+        // Escape backslashes, replace '*' by regexp wildcard (.*)
+        $regexp = '#^' . str_replace(['\\', '*'], ['\\\\', '(.*)'], $pattern) . '$#';
+
+        return preg_match($regexp, $subject) === 1;
+    }
+}

--- a/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidDoctrineClassesSniff.php
+++ b/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidDoctrineClassesSniff.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Sniffs\Doctrine;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
+
+/**
+ * Ensures Doctrine classes are not used outside the persistence layer.
+ */
+class ForbidDoctrineClassesSniff implements Sniff
+{
+    public const FORBIDDEN_CLASS_FOUND = 'ForbiddenDoctrineClassFound';
+
+    /**
+     * List of classes that should not be used.
+     *
+     * @var string[]
+     */
+    public array $forbiddenClasses = [
+        'Doctrine\Common\Persistence\ManagerRegistry',
+        'Doctrine\Persistence\ManagerRegistry',
+        'Doctrine\Persistence\ObjectRepository',
+        'Doctrine\ORM\EntityManager',
+        'Doctrine\ORM\EntityManagerInterface',
+        'Doctrine\ORM\EntityRepository',
+        'Doctrine\ODM\MongoDB\DocumentManager',
+    ];
+
+    /**
+     * List of namespaces allowed to use the forbidden classes.
+     * Add a trailing '\' to also ignore all sub-namespaces within it.
+     *
+     * @var string[]
+     */
+    public array $ignoredNamespaces = [
+        'App\Migration',
+        'App\Persistence',
+        'App\Repository',
+        'Tests\\',
+    ];
+
+    public function register(): array
+    {
+        return [\T_OPEN_TAG];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Get all referenced names in file from native Typehints (no annotations)
+        $referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $stackPtr);
+
+        foreach ($referencedNames as $referencedName) {
+            $pointer = $referencedName->getStartPointer();
+            $name = $referencedName->getNameAsReferencedInFile();
+
+            // Resolve the FQCN by looking at use statements, remove leading '\', compare with forbidden classes.
+            $fullyQualifiedName = ltrim(NamespaceHelper::resolveClassName($phpcsFile, $name, $pointer), '\\');
+            if (!\in_array($fullyQualifiedName, $this->forbiddenClasses, true)) {
+                continue;
+            }
+
+            // Resolve current namespace, and check if it should be ignored.
+            $currentNamespace = NamespaceHelper::findCurrentNamespaceName($phpcsFile, $pointer);
+            if ($currentNamespace === null || $this->isIgnored($currentNamespace)) {
+                continue;
+            }
+
+            $error = sprintf(
+                'The use of Doctrine class "%s" is forbidden in namespace "%s"',
+                $fullyQualifiedName,
+                $currentNamespace,
+            );
+
+            $phpcsFile->addError($error, $pointer, self::FORBIDDEN_CLASS_FOUND);
+        }
+    }
+
+    private function isIgnored(string $currentNamespace): bool
+    {
+        if (in_array($currentNamespace, $this->ignoredNamespaces, true)) {
+            return true;
+        }
+
+        // Handle wildcard exclusions
+        foreach ($this->ignoredNamespaces as $ignoredNamespace) {
+            if (substr($ignoredNamespace, -1) !== '\\') {
+                continue;
+            }
+
+            if (strpos($currentNamespace, $ignoredNamespace) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidRepositoryInjectionSniff.php
+++ b/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidRepositoryInjectionSniff.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Sniffs\Doctrine;
+
+use ETSGlobalCodingStandard\Helpers\PropertyHelper;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+/**
+ * Ensures Doctrine repositories are not injected directly into other services.
+ *
+ * Doctrine repositories have known issues with long-running processes, resulting
+ * in unstable behaviour when an error has occurred earlier in the process, the
+ * connection used by the repository may be closed.
+ * The solution is to inject a higher level service such as the EntityManager and
+ * get the repositories using the <code>getRepository</code> factory method, to
+ * always get a fresh repository instance with a living database connection.
+ */
+class ForbidRepositoryInjectionSniff implements Sniff
+{
+    public const FORBIDDEN_REPOSITORY_INJECTION = 'ForbiddenRepositoryInjection';
+    public const FORBIDDEN_REPOSITORY_PROPERTY = 'ForbiddenRepositoryProperty';
+
+    /**
+     * All classes within this namespace will be considered to be Doctrine repositories.
+     *
+     * @var string[]
+     */
+    public array $repositoryNamespaces = [
+        'App\Repository',
+    ];
+
+    public function register(): array
+    {
+        return [T_FUNCTION, T_PUBLIC, T_PROTECTED, T_PRIVATE];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['type'] !== 'T_FUNCTION') {
+            // We are not on a function token, fallback to property check.
+            $this->checkProperty($phpcsFile, $stackPtr);
+
+            return;
+        }
+
+        $name = FunctionHelper::getName($phpcsFile, $stackPtr);
+        if ($name !== '__construct') {
+            return;
+        }
+
+        $argsTypehints = FunctionHelper::getParametersTypeHints($phpcsFile, $stackPtr);
+        foreach ($argsTypehints as $typehint) {
+            if ($typehint === null) {
+                continue;
+            }
+
+            $type = $typehint->getTypeHint();
+            $fqn = ltrim(NamespaceHelper::resolveClassName($phpcsFile, $type, $stackPtr), '\\');
+
+            if ($this->validateType($fqn)) {
+                continue;
+            }
+
+            $phpcsFile->addError(
+                sprintf('Doctrine repository class "%s" must not be injected', $fqn),
+                $stackPtr,
+                self::FORBIDDEN_REPOSITORY_INJECTION,
+            );
+        }
+    }
+
+    private function checkProperty(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $propertyPointer = TokenHelper::findNext($phpcsFile, [T_FUNCTION, T_CONST, T_VARIABLE], $stackPtr + 1);
+        if ($propertyPointer === null) {
+            return;
+        }
+
+        if ($tokens[$propertyPointer]['code'] !== T_VARIABLE) {
+            return;
+        }
+
+        $type = PropertyHelper::getPropertyType($phpcsFile, $propertyPointer);
+        if ($type === null) {
+            return;
+        }
+
+        $fqn = ltrim(NamespaceHelper::resolveClassName($phpcsFile, $type, $stackPtr), '\\');
+
+        if ($this->validateType($fqn)) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            sprintf('Doctrine repository class "%s" must not be assigned to class property', $fqn),
+            $propertyPointer,
+            self::FORBIDDEN_REPOSITORY_PROPERTY,
+        );
+    }
+
+    private function validateType(string $fqn): bool
+    {
+        foreach ($this->repositoryNamespaces as $repositoryNamespace) {
+            if (strpos($fqn, $repositoryNamespace . '\\') === 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidRepositoryInjectionSniff.php
+++ b/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidRepositoryInjectionSniff.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ETSGlobalCodingStandard\Sniffs\Doctrine;
 
 use ETSGlobalCodingStandard\Helpers\PropertyHelper;
+use ETSGlobalCodingStandard\Helpers\WildcardHelper;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
@@ -27,12 +28,12 @@ class ForbidRepositoryInjectionSniff implements Sniff
     public const FORBIDDEN_REPOSITORY_PROPERTY = 'ForbiddenRepositoryProperty';
 
     /**
-     * All classes within this namespace will be considered to be Doctrine repositories.
+     * All classes matching these FQCN glob patterns will be considered to be Doctrine repositories.
      *
      * @var string[]
      */
-    public array $repositoryNamespaces = [
-        'App\Repository',
+    public array $repositoryNamespacePatterns = [
+        'App\Repository\*Repository',
     ];
 
     public function register(): array
@@ -111,8 +112,8 @@ class ForbidRepositoryInjectionSniff implements Sniff
 
     private function validateType(string $fqn): bool
     {
-        foreach ($this->repositoryNamespaces as $repositoryNamespace) {
-            if (strpos($fqn, $repositoryNamespace . '\\') === 0) {
+        foreach ($this->repositoryNamespacePatterns as $repositoryPattern) {
+            if (WildcardHelper::match($repositoryPattern, $fqn)) {
                 return false;
             }
         }

--- a/src/ETSGlobalCodingStandard/Sniffs/RabbitMQ/ValidPublisherMethodNameSniff.php
+++ b/src/ETSGlobalCodingStandard/Sniffs/RabbitMQ/ValidPublisherMethodNameSniff.php
@@ -80,7 +80,7 @@ class ValidPublisherMethodNameSniff implements Sniff
         $phpcsFile->addErrorOnLine(
             'Invalid publisher method name. It should be a verb in the past form (engind with -ed)',
             $tokens[$methodNamePointer]['line'],
-            self::CODE_INVALID_PUBLISHER_METHOD_NAME
+            self::CODE_INVALID_PUBLISHER_METHOD_NAME,
         );
     }
 }

--- a/tests/ETSGlobalCodingStandard/Helpers/WildcardHelperTest.php
+++ b/tests/ETSGlobalCodingStandard/Helpers/WildcardHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Helpers;
+
+use PHPUnit\Framework\TestCase;
+
+class WildcardHelperTest extends TestCase
+{
+    public function provideTestcases(): array
+    {
+        return [
+            // Match
+            ['App\Repository\*', 'App\Repository\FooRepository', true],
+            ['App\Repository\*', 'App\Repository\RepositoryGetter', true],
+            ['App\Repository\*\*', 'App\Repository\Foo\Foo', true],
+            ['App\Repository\*\*Repository', 'App\Repository\Foo\FooRepository', true],
+            ['App\Domain\*\Repository\*', 'App\Domain\Foo\Repository\Foo', true],
+            ['App\*Bundle\Repository\*Repository', 'App\FooBundle\Repository\FooRepository', true],
+            ['Tests\*', 'Tests\Repository\FooRepository', true],
+
+            // Don't match
+            ['App\Repository\*Repository', 'App\Repository\RepositoryGetter', false],
+            ['App\Domain\*', 'App\Repository\FooRepository', false],
+            ['*Repository', 'App\Repository\Foo', false],
+            ['App\Domain\*\Repository\*', 'App\Domain\Foo\FooRepository', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestcases
+     */
+    public function testWildcard(string $pattern, string $subject, bool $expected): void
+    {
+        self::assertSame($expected, WildcardHelper::match($pattern, $subject));
+    }
+}

--- a/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidDoctrineClassesSniffTest.php
+++ b/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidDoctrineClassesSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Sniffs\Doctrine;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class ForbidDoctrineClassesSniffTest extends TestCase
+{
+    public function testNoErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/data/forbidDoctrineClassesNoErrors.php');
+        self::assertNoSniffErrorInFile($report);
+    }
+
+    public function testErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/data/forbidDoctrineClassesErrors.php');
+
+        self::assertSame(6, $report->getErrorCount());
+
+        self::assertSniffError($report, 16, ForbidDoctrineClassesSniff::FORBIDDEN_CLASS_FOUND);
+        self::assertSniffError($report, 17, ForbidDoctrineClassesSniff::FORBIDDEN_CLASS_FOUND);
+        self::assertSniffError($report, 18, ForbidDoctrineClassesSniff::FORBIDDEN_CLASS_FOUND);
+        self::assertSniffError($report, 19, ForbidDoctrineClassesSniff::FORBIDDEN_CLASS_FOUND);
+        self::assertSniffError($report, 20, ForbidDoctrineClassesSniff::FORBIDDEN_CLASS_FOUND);
+        self::assertSniffError($report, 24, ForbidDoctrineClassesSniff::FORBIDDEN_CLASS_FOUND);
+    }
+}

--- a/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidRepositoryInjectionSniffTest.php
+++ b/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidRepositoryInjectionSniffTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ETSGlobalCodingStandard\Sniffs\Doctrine;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class ForbidRepositoryInjectionSniffTest extends TestCase
+{
+    public function testNoErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/data/forbidRepositoryInjectionNoErrors.php');
+        self::assertNoSniffErrorInFile($report);
+    }
+
+    public function testErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/data/forbidRepositoryInjectionErrors.php');
+
+        self::assertSame(3, $report->getErrorCount());
+
+        self::assertSniffError($report, 8, ForbidRepositoryInjectionSniff::FORBIDDEN_REPOSITORY_PROPERTY);
+        self::assertSniffError($report, 11, ForbidRepositoryInjectionSniff::FORBIDDEN_REPOSITORY_PROPERTY);
+        self::assertSniffError($report, 16, ForbidRepositoryInjectionSniff::FORBIDDEN_REPOSITORY_INJECTION);
+    }
+}

--- a/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidDoctrineClassesErrors.php
+++ b/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidDoctrineClassesErrors.php
@@ -1,0 +1,28 @@
+<?php
+
+// This namespace is not allowed to use doctrine classes
+namespace Domain;
+
+use Doctrine\Common\Persistence\ManagerRegistry as LegacyRegistry;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+class Foo
+{
+    private LegacyRegistry $legacyRegistry;
+    private ManagerRegistry $registry;
+    private ObjectRepository $repository;
+    private EntityManagerInterface $em;
+    public EntityManager $manager;
+
+    private $dm;
+
+    public function __construct(DocumentManager $manager)
+    {
+        $this->dm =$manager;
+    }
+}

--- a/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidDoctrineClassesNoErrors.php
+++ b/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidDoctrineClassesNoErrors.php
@@ -1,0 +1,28 @@
+<?php
+
+// This namespace is allowed to use doctrine classes
+namespace App\Repository;
+
+use Doctrine\Common\Persistence\ManagerRegistry as LegacyRegistry;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+class Foo
+{
+    private LegacyRegistry $legacyRegistry;
+    private ManagerRegistry $registry;
+    private ObjectRepository $repository;
+    private EntityManagerInterface $em;
+    public EntityManager $manager;
+
+    private $dm;
+
+    public function __construct(DocumentManager $manager)
+    {
+        $this->dm =$manager;
+    }
+}

--- a/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidRepositoryInjectionErrors.php
+++ b/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidRepositoryInjectionErrors.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Repository\MyRepository;
+use App\Domain\Service;
+
+class Foo
+{
+    private MyRepository $repository;
+
+    /** @var MyRepository */
+    private $otherRepository;
+
+    /** @var ServiceB  */
+    private $serviceB;
+
+    public function __construct(MyRepository $repository, Service $serviceB) {}
+}

--- a/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidRepositoryInjectionNoErrors.php
+++ b/tests/ETSGlobalCodingStandard/Sniffs/Doctrine/data/forbidRepositoryInjectionNoErrors.php
@@ -1,0 +1,21 @@
+<?php
+
+use Allowed\ServiceA;
+use Allowed\FooRepository;
+
+class Foo
+{
+    private ServiceA $serviceA;
+
+    private FooRepository $repository;
+
+    public function __construct(ServiceA $serviceA, FooRepository $repository) {
+        $this->serviceA = $serviceA;
+        $this->repository = $repository;
+    }
+
+    public function setRepository(FooRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+}


### PR DESCRIPTION
- [x] Add check to forbid usage of Doctrine classes in domain code such as `EntityManager`, `DocumentManager`, `ManagerRegistry`, ...
- [x] Add check to forbid direct injection of doctrine repositories in constructor/properties
