### PR TITLE
EB-0: remove cache due to conflict with phpcbf

### DIFF
--- a/lib/phpcs/phpcs.xml
+++ b/lib/phpcs/phpcs.xml
@@ -3,9 +3,6 @@
     <arg name="extensions" value="php"/>
     <arg name="colors" />
 
-    <arg name="basepath" value="."/>
-    <arg name="cache" value=".phpcs-cache"/>
-    
     <!-- Show progress of the run -->
     <arg value="sp"/>
 


### PR DESCRIPTION
Phpcbf is currently concatenating the absolute path of the file it need to correct, to the relative path "absolutepath" , so the file is not found

ex: 
```
PHP Fatal error:  Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: file_put_contents(/var/www/ETS_SCORING/vendor/etsglobal/php-static-analysis/lib/phpcs/var/www/ETS_SCORING/src/Broker/Publisher/SpooledEtsScoreRosterPublisher.php): Failed to open stream: No such file or directory in /var/www/ETS_SCORING/vendor/squizlabs/php_codesniffer/src/Reports/Cbf.php on line 95 in /var/www/ETS_SCORING/vendor/squizlabs/php_codesniffer/src/Runner.php:608
```