### PR TITLE
EB-0: add new ignored namespaces for DDD microservice archi

### DIFF
--- a/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidDoctrineClassesSniff.php
+++ b/src/ETSGlobalCodingStandard/Sniffs/Doctrine/ForbidDoctrineClassesSniff.php
@@ -42,6 +42,8 @@ class ForbidDoctrineClassesSniff implements Sniff
         'App\Persistence',
         'App\Repository',
         'Tests\\',
+        'ETSGlobal\Infrastructure\Persistence\Doctrine\ODM\Adapter',
+        'ETSGlobal\Infrastructure\Persistence\Doctrine\ODM\Repository\RepositoryGetter',
     ];
 
     public function register(): array


### PR DESCRIPTION
```
src
├── AppBundle
...
├── ETSGlobal
│   ├── Domain
│   │   ├── RepositoryGetter.php
│   │   ├── Repository.php
│   └── Infrastructure
...
│       └── Persistence
│           └── Doctrine
│               └── ODM
│                   ├── Adapter
│                   │   └── DoctrinePersistenceAdapter.php
│                   ├── Mapping
│                   │   └── Test.Test.mongodb.xml
│                   └── Repository
│                       ├── DoctrineODMTestRepository.php
│                       ├── RepositoryGetter
│                                └── DoctrineRepositoryGetter.php
│                       └── DocumentRepository.php
...
```
In our new CRM microservice architecture, the rule `ForbiddenDoctrineClassFound` does not apply to that structure.
Indeed, both files `DoctrineRepositoryGetter` and `DoctrinePersistenceAdapter` are using the `Doctrine\Persistence\ManagerRegistry` and they are not set in the `$ignoredNamespaces` array of directories that we want to exclude.